### PR TITLE
Sync `Cargo.lock` and/or `rust-toolchain.toml` with Zenoh's

### DIFF
--- a/zenoh-jni/Cargo.lock
+++ b/zenoh-jni/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.23",
+ "rustix 0.37.25",
  "slab",
  "socket2 0.4.9",
  "waker-fn",
@@ -177,7 +177,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 0.37.23",
+ "rustix 0.37.25",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2812,7 +2812,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2860,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2868,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "log",
  "serde",
@@ -2880,12 +2880,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "flume 0.11.0",
  "json5",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2914,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "aes",
  "hmac",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "bincode",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2980,11 +2980,12 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
  "flume 0.11.0",
+ "lz4_flex",
  "serde",
  "typenum",
  "zenoh-buffers",
@@ -2996,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3022,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3038,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3063,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3082,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3100,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3120,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3133,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "libloading",
  "log",
@@ -3146,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "const_format",
  "hex",
@@ -3162,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "anyhow",
 ]
@@ -3170,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3185,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3216,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#7fa7d6c631e7f98957291d29193c6d437a66d72e"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
 dependencies = [
  "async-std",
  "async-trait",


### PR DESCRIPTION
Automated synchronization of Cargo.lock and/or rust-toolchain.toml with Zenoh. This is necessary to ensure plugin ABI compatibility.